### PR TITLE
only deploy on a merge to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/master'
         steps:
 
         - name: 'Checkout GitHub Action'


### PR DESCRIPTION
Update the workflow to only run the test, lint and build steps for pull requests. We only want to deploy when changes are merged to master.