### PR TITLE
Fix period event ID strings

### DIFF
--- a/src/events/period_official.py
+++ b/src/events/period_official.py
@@ -30,4 +30,4 @@ class PeriodOfficial(Event):
 
     @property
     def id(self) -> str:
-        return "PER" + str(self.period) + "-OFFICIAL"
+        return "PER" + str(self.period.number) + "-OFFICIAL"

--- a/src/events/period_ready.py
+++ b/src/events/period_ready.py
@@ -30,4 +30,4 @@ class PeriodReady(Event):
 
     @property
     def id(self) -> str:
-        return "PER" + str(self.period) + "-READY"
+        return "PER" + str(self.period.number) + "-READY"

--- a/src/events/period_start.py
+++ b/src/events/period_start.py
@@ -34,7 +34,7 @@ class PeriodStart(Event):
 
     @property
     def id(self) -> str:
-        return "PER" + str(self.period) + "-START"
+        return "PER" + str(self.period.number) + "-START"
 
     def get_post(self, game_data : GameData) -> Optional[str]:
         """


### PR DESCRIPTION
I was using the period string instead of the period number in our event IDs for period events. This would lead to IDs like `PERThe OT period-END` instead of the expected `PER4-END`.