### PR TITLE
Indicate OT or SO in game end events

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -47,6 +47,7 @@ def check_for_updates():
     """
     while True:
 
+        logger.flush()
         logger.log_info("Checking for a game today...")
 
         # Determine if there is a game today

--- a/src/events/game_end.py
+++ b/src/events/game_end.py
@@ -40,15 +40,19 @@ class GameEnd(Event):
         Description:
             Return the event string for a game end event.
         """
-        home = game_data.home.location
-        away = game_data.away.location
-
+        output : str = ""
         event_values = {
-            "winner":     home if self.home_goals > self.away_goals else away,
-            "home_team":  home,
-            "away_team":  away,
-            "home_goals": self.home_goals,
-            "away_goals": self.away_goals,
+            "winner":     game_data.winner,
+            "home_team":  game_data.home.location,
+            "away_team":  game_data.away.location,
+            "home_goals": game_data.home_score,
+            "away_goals": game_data.away_score,
             "hashtags":   game_data.hashtags
         }
-        return templates.GAME_END_TEMPLATE.format(**event_values)
+        if self.period.is_overtime:
+            output = templates.GAME_END_OT_TEMPLATE.format(**event_values)
+        elif self.period.is_shootout:
+            output = templates.GAME_END_SO_TEMPLATE.format(**event_values)
+        else:
+            output = templates.GAME_END_TEMPLATE.format(**event_values)
+        return output

--- a/src/events/period_end.py
+++ b/src/events/period_end.py
@@ -45,7 +45,6 @@ class PeriodEnd(Event):
         event_values = {
             "period":     str(self.period),
             "venue":      game_data.venue,
-            "city":       game_data.city,
             "home_team":  game_data.home.location,
             "away_team":  game_data.away.location,
             "home_goals": self.home_goals,

--- a/src/events/period_start.py
+++ b/src/events/period_start.py
@@ -44,7 +44,6 @@ class PeriodStart(Event):
         event_values = {
             "period":   str(self.period),
             "venue":    game_data.venue,
-            "city":     game_data.city,
             "hashtags": game_data.hashtags
         }
         return templates.PERIOD_START_TEMPLATE.format(**event_values)

--- a/src/generator.py
+++ b/src/generator.py
@@ -67,7 +67,6 @@ class Generator:
             "home_team": self.game_data.home.location,
             "away_team": self.game_data.away.location,
             "venue":     self.game_data.venue,
-            "city":      self.game_data.city,
             "time":      time.strftime("%I:%M %p %Z"),
             "hashtags":  self.game_data.hashtags
         }

--- a/src/logger.py
+++ b/src/logger.py
@@ -7,6 +7,8 @@ import logging
 import logging.handlers
 import sys
 
+LOG_FILE = "bot.log"
+
 class Logger:
     """
     Description:
@@ -19,18 +21,18 @@ class Logger:
         self.logger.setLevel(logging.INFO)
         formatter = logging.Formatter('| %(levelname)s | %(message)s')
 
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setLevel(logging.INFO)
-        stdout_handler.setFormatter(formatter)
+        self.stdout_handler = logging.StreamHandler(sys.stdout)
+        self.stdout_handler.setLevel(logging.INFO)
+        self.stdout_handler.setFormatter(formatter)
 
-        file_handler = logging.handlers.RotatingFileHandler("bot.log",
+        self.file_handler = logging.handlers.RotatingFileHandler(LOG_FILE,
                                                             maxBytes=1000000,
                                                             backupCount=1)
-        file_handler.setLevel(logging.INFO)
-        file_handler.setFormatter(formatter)
+        self.file_handler.setLevel(logging.INFO)
+        self.file_handler.setFormatter(formatter)
 
-        self.logger.addHandler(stdout_handler)
-        self.logger.addHandler(file_handler)
+        self.logger.addHandler(self.stdout_handler)
+        self.logger.addHandler(self.file_handler)
 
 
     def info(self, msg):
@@ -55,6 +57,14 @@ class Logger:
             Log the given message at the debug level.
         """
         self.logger.debug(msg)
+
+
+    def flush(self):
+        """
+        Description:
+            Delete the current log file.
+        """
+        self.file_handler.doRollover()
 
 
 log = Logger()
@@ -82,3 +92,11 @@ def log_verbose(msg):
         Log the given message at the debug level.
     """
     log.verbose(msg)
+
+
+def flush():
+    """
+    Description:
+        Delete the existing log file.
+    """
+    log.flush()

--- a/src/team.py
+++ b/src/team.py
@@ -17,41 +17,41 @@ class Team:
         self._full_name    : str = data["name"]
 
     @property
-    def location(self):
+    def location(self) -> str:
         """Getter for the team location."""
         return self._location
 
     @location.setter
-    def location(self, location):
+    def location(self, location : str):
         """Setter for the team location."""
         self._location = location
 
     @property
-    def team_name(self):
+    def team_name(self) -> str:
         """Getter for the team name."""
         return self._team_name
 
     @team_name.setter
-    def team_name(self, name):
+    def team_name(self, name : str):
         """Setter for the team name."""
         self._team_name = name
 
     @property
-    def abbreviation(self):
+    def abbreviation(self) -> str:
         """Getter for the team abbreviation."""
         return self._abbreviation
 
     @abbreviation.setter
-    def abbreviation(self, abbreviation):
+    def abbreviation(self, abbreviation : str):
         """Setter for the team abbreviation."""
         self._abbreviation = abbreviation
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
         """Getter for the team full name."""
         return self._full_name
 
     @full_name.setter
-    def full_name(self, name):
+    def full_name(self, name : str):
         """Setter for the team full name."""
         self._full_name = name

--- a/src/templates.py
+++ b/src/templates.py
@@ -12,7 +12,7 @@ Description:
 GAME_DAY_TEMPLATE = """
 It's game day!
 
-{home_team} takes on {away_team} at {venue} in {city}. The puck drops at {time}.
+{home_team} takes on {away_team} at {venue}. The puck drops at {time}.
 
 {hashtags}
 """
@@ -24,7 +24,27 @@ It's game day!
 GAME_END_TEMPLATE = """
 The game is over. {winner} wins!
 
-Final Score:
+Final:
+{home_team}: {home_goals}
+{away_team}: {away_goals}
+
+{hashtags}
+"""
+
+GAME_END_OT_TEMPLATE = """
+The game is over. {winner} wins!
+
+Final/OT:
+{home_team}: {home_goals}
+{away_team}: {away_goals}
+
+{hashtags}
+"""
+
+GAME_END_SO_TEMPLATE = """
+The game is over. {winner} wins!
+
+Final/SO:
 {home_team}: {home_goals}
 {away_team}: {away_goals}
 
@@ -37,7 +57,7 @@ Final Score:
 #################################################
 
 PERIOD_START_TEMPLATE = """
-{period} is starting at {venue} in {city}.
+{period} is starting at {venue}.
 
 {hashtags}
 """
@@ -48,7 +68,7 @@ PERIOD_START_TEMPLATE = """
 #################################################
 
 PERIOD_END_TEMPLATE = """
-{period} is over at {venue} in {city}.
+{period} is over at {venue}.
 
 Goals
 {home_team}: {home_goals}

--- a/test/test_data/game_end_events.py
+++ b/test/test_data/game_end_events.py
@@ -19,8 +19,8 @@ game_end_1 = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -43,8 +43,8 @@ game_end_2 = {
         "periodTimeRemaining" : "00:00",
         "dateTime" : "2022-05-18T01:50:34Z",
         "goals" : {
-        "away" : 4,
-        "home" : 1
+            "away" : 4,
+            "home" : 1
         }
     },
     "coordinates" : { }
@@ -67,8 +67,8 @@ game_end_different_event_id = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -91,8 +91,8 @@ game_end_different_event_id_x = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -115,8 +115,8 @@ game_end_different_datetime = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:39:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -139,8 +139,8 @@ game_end_different_period = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -163,8 +163,8 @@ game_end_different_period_time = {
         "periodTimeRemaining" : "11:58",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }
@@ -187,8 +187,8 @@ game_end_different_period_time_remaining = {
         "periodTimeRemaining" : "11:59",
         "dateTime" : "2022-05-18T04:38:08Z",
         "goals" : {
-        "away" : 2,
-        "home" : 3
+            "away" : 2,
+            "home" : 3
         }
     },
     "coordinates" : { }

--- a/test/test_data/game_events.py
+++ b/test/test_data/game_events.py
@@ -14,10 +14,6 @@ game_data = {
             "dateTime": "2022-04-10T17:30:00Z",
             "endDateTime": "2022-04-10T20:12:25Z"
         },
-        "about": {
-            "periodTimeRemaining": "20:00",
-            "ordinalNum": "1st"
-        },
         "teams": {
             "away": {
                 "name": "Boston Bruins",
@@ -35,6 +31,9 @@ game_data = {
                 "teamName": "Capitals",
                 "locationName": "Washington"
             }
+        },
+        "venue": {
+            "name": "Capital One Arena"
         }
     },
     "liveData": {
@@ -85,6 +84,179 @@ game_data = {
     }
 }
 
+game_data_overtime = {
+    "gameData": {
+        "game": {
+            "pk": 2021030164,
+            "season": "20212022",
+            "type": "R"
+        },
+        "datetime": {
+            "dateTime": "2022-04-10T17:30:00Z",
+            "endDateTime": "2022-04-10T20:12:25Z"
+        },
+        "teams": {
+            "away": {
+                "name": "Boston Bruins",
+                "abbreviation": "BOS",
+                "teamName": "Bruins",
+                "locationName": "Boston"
+            },
+            "home": {
+                "name": "Washington Capitals",
+                "venue": {
+                    "name": "Capital One Arena",
+                    "city" : "Washington"
+                },
+                "abbreviation": "WSH",
+                "teamName": "Capitals",
+                "locationName": "Washington"
+            }
+        },
+        "venue": {
+            "name": "Capital One Arena"
+        }
+    },
+    "liveData": {
+        "linescore": {
+            "teams": {
+                "home": {
+                    "team": {
+                        "id": 15,
+                        "name": "Washington Capitals",
+                        "link": "/api/v1/teams/15",
+                        "abbreviation": "WSH",
+                        "triCode": "WSH"
+                    },
+                    "goals": 4,
+                    "shotsOnGoal": 33,
+                    "goaliePulled": False,
+                    "numSkaters": 5,
+                    "powerPlay": False
+                },
+                "away": {
+                    "team": {
+                        "id": 6,
+                        "name": "Boston Bruins",
+                        "link": "/api/v1/teams/6",
+                        "abbreviation": "BOS",
+                        "triCode": "BOS"
+                    },
+                    "goals": 3,
+                    "shotsOnGoal": 30,
+                    "goaliePulled": False,
+                    "numSkaters": 5,
+                    "powerPlay": False
+                }
+            },
+            "powerPlayStrength" : "Even",
+            "hasShootout" : False,
+            "intermissionInfo" : {
+                "intermissiontime_remainingaining" : 0,
+                "intermissionTimeElapsed" : 0,
+                "inIntermission" : False
+            },
+            "powerPlayInfo" : {
+                "situationtime_remainingaining" : 0,
+                "situationTimeElapsed" : 0,
+                "inSituation" : False
+            }
+        }
+    }
+}
+
+game_data_shootout = {
+    "gameData": {
+        "game": {
+            "pk": 2021030164,
+            "season": "20212022",
+            "type": "R"
+        },
+        "datetime": {
+            "dateTime": "2022-04-10T17:30:00Z",
+            "endDateTime": "2022-04-10T20:12:25Z"
+        },
+        "teams": {
+            "away": {
+                "name": "Boston Bruins",
+                "abbreviation": "BOS",
+                "teamName": "Bruins",
+                "locationName": "Boston"
+            },
+            "home": {
+                "name": "Washington Capitals",
+                "venue": {
+                    "name": "Capital One Arena",
+                    "city" : "Washington"
+                },
+                "abbreviation": "WSH",
+                "teamName": "Capitals",
+                "locationName": "Washington"
+            }
+        },
+        "venue": {
+            "name": "Capital One Arena"
+        }
+    },
+    "liveData": {
+        "linescore": {
+            "shootoutInfo" : {
+                "away" : {
+                    "scores" : 0,
+                    "attempts" : 3
+                },
+                "home" : {
+                    "scores" : 1,
+                    "attempts" : 2
+                },
+                "startTime" : "2022-12-20T04:49:18Z"
+            },
+            "teams": {
+                "home": {
+                    "team": {
+                        "id": 15,
+                        "name": "Washington Capitals",
+                        "link": "/api/v1/teams/15",
+                        "abbreviation": "WSH",
+                        "triCode": "WSH"
+                    },
+                    "goals": 4,
+                    "shotsOnGoal": 33,
+                    "goaliePulled": False,
+                    "numSkaters": 5,
+                    "powerPlay": False
+                },
+                "away": {
+                    "team": {
+                        "id": 6,
+                        "name": "Boston Bruins",
+                        "link": "/api/v1/teams/6",
+                        "abbreviation": "BOS",
+                        "triCode": "BOS"
+                    },
+                    "goals": 4,
+                    "shotsOnGoal": 30,
+                    "goaliePulled": False,
+                    "numSkaters": 5,
+                    "powerPlay": False
+                }
+            },
+            "powerPlayStrength" : "Even",
+            "hasShootout" : True,
+            "intermissionInfo" : {
+                "intermissiontime_remainingaining" : 0,
+                "intermissionTimeElapsed" : 0,
+                "inIntermission" : False
+            },
+            "powerPlayInfo" : {
+                "situationtime_remainingaining" : 0,
+                "situationTimeElapsed" : 0,
+                "inSituation" : False
+            }
+        }
+    }
+}
+
 playoff_game_data = {
     "gameData": {
         "game": {
@@ -95,10 +267,6 @@ playoff_game_data = {
         "datetime": {
             "dateTime": "2022-04-10T17:30:00Z",
             "endDateTime": "2022-04-10T20:12:25Z"
-        },
-        "about": {
-            "periodTimeRemaining": "20:00",
-            "ordinalNum": "1st"
         },
         "teams": {
             "away": {
@@ -197,6 +365,54 @@ game_end_data = {
         "goals": {
             "away": 2,
             "home": 4
+        }
+    },
+    "coordinates": {}
+}
+
+game_end_overtime_data = {
+    "result": {
+        "event": "Game End",
+        "eventCode": "WSH915",
+        "eventTypeId": "GAME_END",
+        "description": "Game End"
+    },
+    "about": {
+        "eventIdx": 384,
+        "eventId": 915,
+        "period": 3,
+        "periodType": "OVERTIME",
+        "ordinalNum": "4th",
+        "periodTime": "20:00",
+        "periodTimeRemaining": "00:00",
+        "dateTime": "2022-04-10T20:12:25Z",
+        "goals": {
+            "away": 3,
+            "home": 4
+        }
+    },
+    "coordinates": {}
+}
+
+game_end_shootout_data = {
+    "result": {
+        "event": "Game End",
+        "eventCode": "WSH915",
+        "eventTypeId": "GAME_END",
+        "description": "Game End"
+    },
+    "about": {
+        "eventIdx": 384,
+        "eventId": 915,
+        "period": 3,
+        "periodType": "SHOOTOUT",
+        "ordinalNum": "5th",
+        "periodTime": "20:00",
+        "periodTimeRemaining": "00:00",
+        "dateTime": "2022-04-10T20:12:25Z",
+        "goals": {
+            "away": 3,
+            "home": 3
         }
     },
     "coordinates": {}

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -701,7 +701,7 @@ class TestEvents(unittest.TestCase):
         event     = event_factory.create(game_events.game_end_data)
         game_data = GameData(game_events.game_data)
         actual    = event.get_post(game_data)
-        expected  = "\nThe game is over. Washington wins!\n\nFinal Score:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #GoAvsGo\n"
+        expected  = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 
@@ -868,7 +868,7 @@ class TestEvents(unittest.TestCase):
         event     = event_factory.create(period_events.period_start_data)
         game_data = GameData(game_events.game_data)
         actual    = event.get_post(game_data)
-        expected  = "\nThe second period is starting at Capital One Arena in Washington.\n\n#BOSvsWSH #GoAvsGo\n"
+        expected  = "\nThe second period is starting at Capital One Arena.\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 
@@ -880,7 +880,7 @@ class TestEvents(unittest.TestCase):
         event     = event_factory.create(period_events.period_end_data)
         game_data = GameData(game_events.game_data)
         actual    = event.get_post(game_data)
-        expected  = "\nThe first period is over at Capital One Arena in Washington.\n\nGoals\nWashington: 0\nBoston: 0\n\nShots on Goal\nWashington: 33\nBoston: 30\n\n#BOSvsWSH #GoAvsGo\n"
+        expected  = "\nThe first period is over at Capital One Arena.\n\nGoals\nWashington: 0\nBoston: 0\n\nShots on Goal\nWashington: 33\nBoston: 30\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -10,6 +10,7 @@ from test.test_data import miscellaneous_events
 from test.test_data import penalty_events
 from test.test_data import period_events
 
+from src import game_data
 from src import generator
 from src import event_factory
 
@@ -59,14 +60,39 @@ class TestGenerator(unittest.TestCase):
         self.assertEqual(expected, actual)
 
 
-    def test_game_end(self):
+    def test_game_end_regulation(self):
         """
         Description:
             Test the expected output of a game end event.
         """
+        self.generator.game_data = game_data.GameData(game_events.game_data)
         event    = event_factory.create(game_events.game_end_data)
         actual   = self.generator.get_event_string(event)
-        expected = "\nThe game is over. Washington wins!\n\nFinal Score:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #GoAvsGo\n"
+        expected = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #GoAvsGo\n"
+        self.assertEqual(expected, actual)
+
+
+    def test_game_end_overtime(self):
+        """
+        Description:
+            Test the expected output of a game end event.
+        """
+        self.generator.game_data = game_data.GameData(game_events.game_data_overtime)
+        event    = event_factory.create(game_events.game_end_overtime_data)
+        actual   = self.generator.get_event_string(event)
+        expected = "\nThe game is over. Washington wins!\n\nFinal/OT:\nWashington: 4\nBoston: 3\n\n#BOSvsWSH #GoAvsGo\n"
+        self.assertEqual(expected, actual)
+
+
+    def test_game_end_shootout(self):
+        """
+        Description:
+            Test the expected output of a game end event.
+        """
+        self.generator.game_data = game_data.GameData(game_events.game_data_shootout)
+        event    = event_factory.create(game_events.game_end_shootout_data)
+        actual   = self.generator.get_event_string(event)
+        expected = "\nThe game is over. Washington wins!\n\nFinal/SO:\nWashington: 5\nBoston: 4\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 
@@ -220,7 +246,7 @@ class TestGenerator(unittest.TestCase):
         """
         event    = event_factory.create(period_events.period_start_data)
         actual   = self.generator.get_event_string(event)
-        expected = "\nThe second period is starting at Capital One Arena in Washington.\n\n#BOSvsWSH #GoAvsGo\n"
+        expected = "\nThe second period is starting at Capital One Arena.\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 
@@ -231,7 +257,7 @@ class TestGenerator(unittest.TestCase):
         """
         event    = event_factory.create(period_events.period_end_data)
         actual   = self.generator.get_event_string(event)
-        expected = "\nThe first period is over at Capital One Arena in Washington.\n\nGoals\nWashington: 0\nBoston: 0\n\nShots on Goal\nWashington: 33\nBoston: 30\n\n#BOSvsWSH #GoAvsGo\n"
+        expected = "\nThe first period is over at Capital One Arena.\n\nGoals\nWashington: 0\nBoston: 0\n\nShots on Goal\nWashington: 33\nBoston: 30\n\n#BOSvsWSH #GoAvsGo\n"
         self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
A couple of different fixes in this merge:

- Handle OT and SO games differently when posting the final end of game tweet.
- Fix final score and winner for games that go to a shootout.
- Handle neutral-site game venues correctly.
- Flush logs between games.
- Update line score to include shootout data.