### PR TITLE
Fix issue with game day tweets on SEGABABAs

### DIFF
--- a/src/json_parser.py
+++ b/src/json_parser.py
@@ -173,7 +173,7 @@ class Parser:
             duplicate.
         """
 
-        if not output.has_posted_today():
+        if not output.has_posted_today("game day"):
             text : Optional[str] = self.generator.get_game_day_string()
             if text is not None:
                 output.post(text)

--- a/src/output.py
+++ b/src/output.py
@@ -78,9 +78,9 @@ def reply(text : str, parent_id : Optional[int]) -> Optional[int]:
     return output.outputter.reply(text, parent_id)
 
 
-def has_posted_today() -> bool:
+def has_posted_today(query : str = "") -> bool:
     """
     Description:
         Return a boolean indicating whether or not we've posted today.
     """
-    return output.outputter.has_posted_today()
+    return output.outputter.has_posted_today(query)

--- a/src/outputter.py
+++ b/src/outputter.py
@@ -28,7 +28,7 @@ class Outputter(ABC):
         """
 
     @abstractmethod
-    def has_posted_today(self):
+    def has_posted_today(self, _query : str = ""):
         """
         Description:
             Return a boolean indicating whether or not we've posted today.

--- a/src/printer.py
+++ b/src/printer.py
@@ -38,7 +38,7 @@ class Printer(Outputter):
         return reply_id
 
 
-    def has_posted_today(self):
+    def has_posted_today(self, _query : str = ""):
         """
         Description:
             Return a boolean indicating whether or not we've posted today.

--- a/src/tweeter.py
+++ b/src/tweeter.py
@@ -4,7 +4,7 @@ Description:
     authenticate, tweet and reply.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 import os
 from os.path import join, dirname, abspath
@@ -105,26 +105,29 @@ class Tweeter(Outputter):
         return reply_id
 
 
-    def get_today_posts(self) -> List[tweepy.Tweet]:
+    def get_today_posts(self, query : str = "") -> List[tweepy.Tweet]:
         """
         Description:
-            Return a list of tweets that were created today.
+            Return a list of tweets that were created today. If a query is
+            provided, return only tweets that include the query as a substring.
         """
 
-        all_tweets   : List[tweepy.Tweet] = self.api.user_timeline()
+        all_tweets   : List[tweepy.Tweet] = self.api.user_timeline(count=50, exclude_replies=True)
         today_tweets : List[tweepy.Tweet] = []
+        period       : timedelta          = timedelta(hours=23, minutes=59)
 
         for tweet in all_tweets:
-            if (datetime.now(pytz.utc) - tweet.created_at).days < 1:
+            if ((datetime.now(pytz.utc) - tweet.created_at) < period and
+                query in tweet.text):
                 today_tweets.append(tweet)
 
         return today_tweets
 
 
-    def has_posted_today(self) -> bool:
+    def has_posted_today(self, query : str = "") -> bool:
         """
         Description:
             Return a boolean indicating whether or not a tweet has been sent today.
         """
-        tweets = self.get_today_posts()
+        tweets = self.get_today_posts(query)
         return len(tweets) > 0


### PR DESCRIPTION
Part two of the fix for missing the second game in a back-to-back. Updates the game day tweet logic to check specifically for game day tweets that have gone out in the last 23 hours and 59 minutes. 