### PR TITLE
Move game end post to game official event

### DIFF
--- a/src/events/game_end.py
+++ b/src/events/game_end.py
@@ -2,28 +2,8 @@
 This module defines the Game End event.
 """
 
-from typing import Optional
-
-from src.data.line_score import LineScore
-from src.output import templates
 from src.events.event import Event
-from src.data.game_data import GameData
-from src.logger import log
 from src.utils import pad_code
-
-
-def winner(game_data: GameData, line_score: LineScore) -> str:
-    """
-    Return the winner of the game.
-    """
-    team: str = "Nobody"
-    if line_score.is_home_winner:
-        team = game_data.home.location
-    elif line_score.is_away_winner:
-        team = game_data.away.location
-    else:
-        log.error("Attempted to determine winner, but teams are tied.")
-    return team
 
 
 class GameEnd(Event):
@@ -49,25 +29,3 @@ class GameEnd(Event):
     @property
     def id(self) -> str:
         return "GAME-END"
-
-
-    def get_post(self, game_data: GameData, line_score: LineScore) -> Optional[str]:
-        """
-        Return the event string for a game end event.
-        """
-        output: str = ""
-        event_values = {
-            "winner":     winner(game_data, line_score),
-            "home_team":  game_data.home.location,
-            "away_team":  game_data.away.location,
-            "home_goals": line_score.home_score,
-            "away_goals": line_score.away_score,
-            "hashtags":   game_data.hashtags
-        }
-        if self.period.is_overtime:
-            output = templates.GAME_END_OT_TEMPLATE.format(**event_values)
-        elif self.period.is_shootout:
-            output = templates.GAME_END_SO_TEMPLATE.format(**event_values)
-        else:
-            output = templates.GAME_END_TEMPLATE.format(**event_values)
-        return output

--- a/src/events/game_official.py
+++ b/src/events/game_official.py
@@ -2,8 +2,27 @@
 This module defines the Game Official event.
 """
 
+from typing import Optional
+
+from src.data.line_score import LineScore
+from src.output import templates
 from src.events.event import Event
+from src.data.game_data import GameData
+from src.logger import log
 from src.utils import pad_code
+
+def winner(game_data: GameData, line_score: LineScore) -> str:
+    """
+    Return the winner of the game.
+    """
+    team: str = "Nobody"
+    if line_score.is_home_winner:
+        team = game_data.home.location
+    elif line_score.is_away_winner:
+        team = game_data.away.location
+    else:
+        log.error("Attempted to determine winner, but teams are tied.")
+    return team
 
 class GameOfficial(Event):
     """
@@ -28,3 +47,24 @@ class GameOfficial(Event):
     @property
     def id(self) -> str:
         return "GAME-OFFICIAL"
+
+    def get_post(self, game_data: GameData, line_score: LineScore) -> Optional[str]:
+        """
+        Return the event string for a game end event.
+        """
+        output: str = ""
+        event_values = {
+            "winner":     winner(game_data, line_score),
+            "home_team":  game_data.home.location,
+            "away_team":  game_data.away.location,
+            "home_goals": line_score.home_score,
+            "away_goals": line_score.away_score,
+            "hashtags":   game_data.hashtags
+        }
+        if self.period.is_overtime:
+            output = templates.GAME_END_OT_TEMPLATE.format(**event_values)
+        elif self.period.is_shootout:
+            output = templates.GAME_END_SO_TEMPLATE.format(**event_values)
+        else:
+            output = templates.GAME_END_TEMPLATE.format(**event_values)
+        return output

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -698,7 +698,7 @@ class TestEvents(unittest.TestCase):
         game_data  = GameData(game_events.game_data)
         line_score = LineScore(game_events.game_data["liveData"]["linescore"])
         actual     = event.get_post(game_data, line_score)
-        expected   = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #ALLCAPS #NHLBruins\n"
+        expected   = None
         self.assertEqual(expected, actual)
 
 
@@ -710,7 +710,7 @@ class TestEvents(unittest.TestCase):
         game_data  = GameData(game_events.game_data)
         line_score = LineScore(game_events.game_data["liveData"]["linescore"])
         actual     = event.get_post(game_data, line_score)
-        expected   = None
+        expected   = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #ALLCAPS #NHLBruins\n"
         self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
Attempting to resolve the issue where the score is not correct in the end of game tweet. This only seems to happen after the game ends via a shootout (maybe OT too?). My theory is that the line score hasn't been updated yet when the event occurs and we're ending up with either the wrong number of goals or shootout goals (which is how we determine our winner). Delaying the tweet until the game official event instead of the game end event will hopefully delay things sufficiently so that the line score has had time to update.