### PR TITLE
Fix priority queue ordering for tiebreakers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv == 0.19.2
 pause == 0.3
 pyclean == 2.7.0
 pylint == 2.13.5
-pytest == 7.0.1
+pytest == 7.1.1
 pytz == 2022.1
 requests == 2.27.1
 tweepy == 4.6.0
@@ -16,4 +16,5 @@ types-pytz == 2021.3.8
 types-requests == 2.27.25
 types-urllib3 == 1.26.14
 types-waitress == 2.1.4.3
+urllib3 == 1.26.15
 waitress == 2.1.1

--- a/src/command/command.py
+++ b/src/command/command.py
@@ -36,4 +36,4 @@ class Command(ABC):
 
 
     def __lt__(self, other) -> bool:
-        return self.priority == Priority.HIGH and other.priority != Priority.HIGH
+        return self.priority == Priority.NORMAL and other.priority != Priority.NORMAL

--- a/src/events/game_end.py
+++ b/src/events/game_end.py
@@ -2,9 +2,27 @@
 This module defines the Game End event.
 """
 
+from typing import Optional
+
+from src.data.line_score import LineScore
+from src.output import templates
 from src.events.event import Event
+from src.data.game_data import GameData
+from src.logger import log
 from src.utils import pad_code
 
+def winner(game_data: GameData, line_score: LineScore) -> str:
+    """
+    Return the winner of the game.
+    """
+    team: str = "Nobody"
+    if line_score.is_home_winner:
+        team = game_data.home.location
+    elif line_score.is_away_winner:
+        team = game_data.away.location
+    else:
+        log.error("Attempted to determine winner, but teams are tied.")
+    return team
 
 class GameEnd(Event):
     """
@@ -29,3 +47,24 @@ class GameEnd(Event):
     @property
     def id(self) -> str:
         return "GAME-END"
+
+    def get_post(self, game_data: GameData, line_score: LineScore) -> Optional[str]:
+        """
+        Return the event string for a game end event.
+        """
+        output: str = ""
+        event_values = {
+            "winner":     winner(game_data, line_score),
+            "home_team":  game_data.home.location,
+            "away_team":  game_data.away.location,
+            "home_goals": line_score.home_score,
+            "away_goals": line_score.away_score,
+            "hashtags":   game_data.hashtags
+        }
+        if self.period.is_overtime:
+            output = templates.GAME_END_OT_TEMPLATE.format(**event_values)
+        elif self.period.is_shootout:
+            output = templates.GAME_END_SO_TEMPLATE.format(**event_values)
+        else:
+            output = templates.GAME_END_TEMPLATE.format(**event_values)
+        return output

--- a/src/events/game_official.py
+++ b/src/events/game_official.py
@@ -2,27 +2,8 @@
 This module defines the Game Official event.
 """
 
-from typing import Optional
-
-from src.data.line_score import LineScore
-from src.output import templates
 from src.events.event import Event
-from src.data.game_data import GameData
-from src.logger import log
 from src.utils import pad_code
-
-def winner(game_data: GameData, line_score: LineScore) -> str:
-    """
-    Return the winner of the game.
-    """
-    team: str = "Nobody"
-    if line_score.is_home_winner:
-        team = game_data.home.location
-    elif line_score.is_away_winner:
-        team = game_data.away.location
-    else:
-        log.error("Attempted to determine winner, but teams are tied.")
-    return team
 
 class GameOfficial(Event):
     """
@@ -47,24 +28,3 @@ class GameOfficial(Event):
     @property
     def id(self) -> str:
         return "GAME-OFFICIAL"
-
-    def get_post(self, game_data: GameData, line_score: LineScore) -> Optional[str]:
-        """
-        Return the event string for a game end event.
-        """
-        output: str = ""
-        event_values = {
-            "winner":     winner(game_data, line_score),
-            "home_team":  game_data.home.location,
-            "away_team":  game_data.away.location,
-            "home_goals": line_score.home_score,
-            "away_goals": line_score.away_score,
-            "hashtags":   game_data.hashtags
-        }
-        if self.period.is_overtime:
-            output = templates.GAME_END_OT_TEMPLATE.format(**event_values)
-        elif self.period.is_shootout:
-            output = templates.GAME_END_SO_TEMPLATE.format(**event_values)
-        else:
-            output = templates.GAME_END_TEMPLATE.format(**event_values)
-        return output

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -698,7 +698,7 @@ class TestEvents(unittest.TestCase):
         game_data  = GameData(game_events.game_data)
         line_score = LineScore(game_events.game_data["liveData"]["linescore"])
         actual     = event.get_post(game_data, line_score)
-        expected   = None
+        expected   = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #ALLCAPS #NHLBruins\n"
         self.assertEqual(expected, actual)
 
 
@@ -710,7 +710,7 @@ class TestEvents(unittest.TestCase):
         game_data  = GameData(game_events.game_data)
         line_score = LineScore(game_events.game_data["liveData"]["linescore"])
         actual     = event.get_post(game_data, line_score)
-        expected   = "\nThe game is over. Washington wins!\n\nFinal:\nWashington: 4\nBoston: 2\n\n#BOSvsWSH #ALLCAPS #NHLBruins\n"
+        expected   = None
         self.assertEqual(expected, actual)
 
 

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -1,0 +1,106 @@
+"""
+Test the order of commands in the command queue.
+"""
+
+
+import unittest
+
+from src.command.command import Command, Priority
+from src.command.command_queue import CommandQueue
+
+class A(Command):
+    def __init__(self):
+        super().__init__("A", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class B(Command):
+    def __init__(self):
+        super().__init__("B", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class C(Command):
+    def __init__(self):
+        super().__init__("C", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class D(Command):
+    def __init__(self):
+        super().__init__("D", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class E(Command):
+    def __init__(self):
+        super().__init__("E", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class F(Command):
+    def __init__(self):
+        super().__init__("F", Priority.HIGH)
+    def execute(self) -> None:
+        pass
+
+class G(Command):
+    def __init__(self):
+        super().__init__("G", Priority.NORMAL)
+    def execute(self) -> None:
+        pass
+
+class H(Command):
+    def __init__(self):
+        super().__init__("H", Priority.HIGH)
+    def execute(self) -> None:
+        pass
+
+class TestQueue(unittest.TestCase):
+    """
+    Unit tests for the command queue.
+    """
+
+    def test_command_order(self):
+        """
+        Test the order of commands in the priority queue.
+        """
+        queue = CommandQueue()
+
+        queue.enqueue(A())
+        queue.enqueue(B())
+        queue.enqueue(C())
+        queue.enqueue(D())
+
+        self.assertEqual(queue.dequeue().name, "A")
+        self.assertEqual(queue.dequeue().name, "B")
+        self.assertEqual(queue.dequeue().name, "C")
+        self.assertEqual(queue.dequeue().name, "D")
+
+        queue.enqueue(E())
+        queue.enqueue(F())
+        queue.enqueue(G())
+        queue.enqueue(H())
+
+        self.assertEqual(queue.dequeue().name, "F")
+        self.assertEqual(queue.dequeue().name, "H")
+        self.assertEqual(queue.dequeue().name, "E")
+        self.assertEqual(queue.dequeue().name, "G")
+
+        queue.enqueue(A())
+        queue.enqueue(B())
+        queue.enqueue(C())
+        queue.enqueue(D())
+        queue.enqueue(E())
+        queue.enqueue(F())
+        queue.enqueue(G())
+        queue.enqueue(H())
+
+        self.assertEqual(queue.dequeue().name, "F")
+        self.assertEqual(queue.dequeue().name, "H")
+        self.assertEqual(queue.dequeue().name, "A")
+        self.assertEqual(queue.dequeue().name, "B")
+        self.assertEqual(queue.dequeue().name, "C")
+        self.assertEqual(queue.dequeue().name, "D")
+        self.assertEqual(queue.dequeue().name, "E")
+        self.assertEqual(queue.dequeue().name, "G")


### PR DESCRIPTION
The Python priority queue uses a heap to store its elements. This means that elements with the same priority are not going to necessarily be output in FIFO order. We want this in order to ensure that game events are processed in the correct order when they are enqueued in quick succession. 

I've reworked the command queue to use a list ordered by priority first and chronology second. This should result in commands being dequeued in the proper order. I've also added a unit test to verify that this order is correct in the future.